### PR TITLE
Update the code to remove IntelliPhense Warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Usage
 
 Character encoding conversion:
 
+    require 'path/to/camellia/converter.php';
     $string = 'String encoded by Shift_JIS.';
     $conv = new Camellia_Converter;
     $string = $conv->convert('Shift_JIS', 'UTF-8', $string);

--- a/converter.php
+++ b/converter.php
@@ -517,7 +517,7 @@ class Camellia_Converter
    * An array to function to charset conversion
    *
    * @access private
-   * @var array $_conversion_handlers (conversion rule => callback)
+   * @var array $_conversion_handlers (conversion rule => callback / callable)
    */
   var $_conversion_handlers = array(
     // JIS based CES
@@ -730,7 +730,7 @@ class Camellia_Converter
    * A handler function to process unmappable characters
    *
    * @access private
-   * @var callback $_replace_handler
+   * @var callable $_replace_handler
    */
   var $_replace_handler;
 
@@ -752,7 +752,7 @@ class Camellia_Converter
    */
   function availableCharsets()
   {
-    return $_available_charsets;
+    return $this->_available_charsets;
   }
 
   /**
@@ -860,7 +860,7 @@ class Camellia_Converter
    * Sets a handler function to process unmappable characters
    *
    * @access public
-   * @param callback $handler Handler function
+   * @param callable $handler Handler function
    * @return boolean TRUE on success; FALSE on failure
    */
   function setReplaceHandler($handler)
@@ -880,7 +880,7 @@ class Camellia_Converter
    * Returns a handler function to process unmappable characters
    *
    * @access public
-   * @return callback
+   * @return callable
    */
   function getReplaceHandler()
   {


### PR DESCRIPTION
I updated the code to remove the IntelliPhense  warning related to 
- callback now callable
- _available_charsets not static so not found without $this->  
however we could have
public static $_available_charsets = array( ... );
public static function availableCharsets()
  {
    return self::$_available_charsets;
  }
  
 but not sure if desired behavior.